### PR TITLE
feat(gradle-config): update config

### DIFF
--- a/app/src/main/java/com/soul/taskbreeze/core/network/Api.kt
+++ b/app/src/main/java/com/soul/taskbreeze/core/network/Api.kt
@@ -1,7 +1,7 @@
 package com.soul.taskbreeze.core.network
 
 object Api {
-    const val BASE_URL = "http://10.0.2.2:8000"
+    const val BASE_URL = "https://taskbreezeapi.pythonanywhere.com"
     const val PRE_APP_DETAILS = "/api/pre/app-details"
 
     // LOGIN APIS

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.5.0"
 kotlin = "2.0.21"
 coreKtx = "1.15.0"
 junit = "4.13.2"


### PR DESCRIPTION
## Description

1. Downgraded AGP(Android Gradle Plugin) version from 8.7.3 to 8.5.0 because project was not running in Android Studio Koala 2024.1.1 (11 June), 2024.
2. Updated Base API URL from http://10.0.2.2:8000 to https://taskbreezeapi.pythonanywhere.com.